### PR TITLE
Adds command-line parsing package to determine service running mode.

### DIFF
--- a/ApplicationStartup.cs
+++ b/ApplicationStartup.cs
@@ -10,28 +10,27 @@ namespace poc_windowsservice_preflightcheck
     {
         public static StartupMode GetStartupMode()
         {
+            var options = new CommandLineOptions();
+
             try
             {
-                var options = new CommandLineOptions();
                 var isValid = CommandLine.Parser.Default.ParseArguments(Environment.GetCommandLineArgs(), options);
-
-                if (isValid && options.Preflight)
-                    return StartupMode.RunPreflightCheck;
+                if (isValid && options.PreflightCheck)
+                    return StartupMode.Preflight;
             }
             catch(Exception e)
             {
-                Console.WriteLine("Encountered an exception trying to determine StartupMode [RunNormally, RunPreflightCheck].");
-                Console.WriteLine(e.ToString());
+                Console.Error.WriteLine(e.ToString());
+                Console.Error.WriteLine(options.GetUsage());
             }
 
-            return StartupMode.RunNormally;
+            return StartupMode.Normal;
         }
-
     }
 
     public enum StartupMode
     {
-        RunNormally,
-        RunPreflightCheck,
+        Normal,
+        Preflight,
     }
 }

--- a/ApplicationStartup.cs
+++ b/ApplicationStartup.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace poc_windowsservice_preflightcheck
+{
+    public static class ApplicationStartup
+    {
+        public static StartupMode GetStartupMode()
+        {
+            try
+            {
+                var options = new CommandLineOptions();
+                var isValid = CommandLine.Parser.Default.ParseArguments(Environment.GetCommandLineArgs(), options);
+
+                if (isValid && options.Preflight)
+                    return StartupMode.RunPreflightCheck;
+            }
+            catch(Exception e)
+            {
+                Console.WriteLine("Encountered an exception trying to determine StartupMode [RunNormally, RunPreflightCheck].");
+                Console.WriteLine(e.ToString());
+            }
+
+            return StartupMode.RunNormally;
+        }
+
+    }
+
+    public enum StartupMode
+    {
+        RunNormally,
+        RunPreflightCheck,
+    }
+}

--- a/CommandLineOptions.cs
+++ b/CommandLineOptions.cs
@@ -9,7 +9,20 @@ namespace poc_windowsservice_preflightcheck
 {
     public class CommandLineOptions
     {
-        [Option(HelpText = "Starts the application in a pre-flight mode to validate whether application is good to go.")]
-        public bool Preflight { get; set; }
+        [Option('p', "preflight")]
+        public bool PreflightCheck { get; set; }
+
+        [HelpOption]
+        public string GetUsage()
+        {
+            return
+                @"Usage:
+                poc-windowsservice-preflightcheck.exe [--preflight]
+                
+                --preflight Starts the application in a pre-flight mode to validate whether application is good to go. 
+                            Application will return exit code 0 (success) or 1 (failure).
+                
+                ";
+        }
     }
 }

--- a/CommandLineOptions.cs
+++ b/CommandLineOptions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CommandLine;
+
+namespace poc_windowsservice_preflightcheck
+{
+    public class CommandLineOptions
+    {
+        [Option(HelpText = "Starts the application in a pre-flight mode to validate whether application is good to go.")]
+        public bool Preflight { get; set; }
+    }
+}

--- a/MyService.cs
+++ b/MyService.cs
@@ -26,8 +26,8 @@ namespace poc_windowsservice_preflightcheck
             }
             else
             {
-                Console.WriteLine("Pre-flight check failed.");
-                Console.WriteLine("Returning exit code 1.");
+                Console.Error.WriteLine("Pre-flight check failed.");
+                Console.Error.WriteLine("Returning exit code 1.");
             }
 
             Console.WriteLine("Type the following command on your Powershell terminal to find the exit code of the most recently exited process:");

--- a/MyService.cs
+++ b/MyService.cs
@@ -13,34 +13,32 @@ namespace poc_windowsservice_preflightcheck
             Console.WriteLine("Service is exiting.");
         }
 
-        public void Start(bool preflight)
+        public void PreFlightCheck()
         {
-            if (preflight)
+            Console.WriteLine("Running a preflight check...");
+
+            var canBeZeroOrOne = new Random().Next(2);
+
+            if (canBeZeroOrOne == 0)
             {
-                Console.WriteLine("Running a preflight check...");
-
-                var canBeZeroOrOne = new Random().Next(2);
-
-                if (canBeZeroOrOne == 0)
-                {
-                    Console.WriteLine("Pre-flight check successful. Process is ready to run!");
-                    Console.WriteLine("Returning exit code 0.");
-                }
-                else
-                {
-                    Console.WriteLine("Pre-flight check failed.");
-                    Console.WriteLine("Returning exit code 1.");
-                }
-
-                Console.WriteLine("Type the following command on your Powershell terminal to find the exit code of the most recently exited process:");
-                Console.WriteLine("echo $LastExitCode");
-
-                Environment.Exit(canBeZeroOrOne);
+                Console.WriteLine("Pre-flight check successful. Process is ready to run!");
+                Console.WriteLine("Returning exit code 0.");
             }
             else
             {
-                Console.WriteLine("Pre-flight mode wasn't specified. Running normally.");
+                Console.WriteLine("Pre-flight check failed.");
+                Console.WriteLine("Returning exit code 1.");
             }
+
+            Console.WriteLine("Type the following command on your Powershell terminal to find the exit code of the most recently exited process:");
+            Console.WriteLine("echo $LastExitCode");
+
+            Environment.Exit(canBeZeroOrOne);
+        }
+
+        public void Start()
+        {
+            Console.WriteLine("Pre-flight mode wasn't specified. Running normally.");
         }
     }
 }

--- a/MyService.cs
+++ b/MyService.cs
@@ -30,8 +30,9 @@ namespace poc_windowsservice_preflightcheck
                 Console.Error.WriteLine("Returning exit code 1.");
             }
 
-            Console.WriteLine("Type the following command on your Powershell terminal to find the exit code of the most recently exited process:");
-            Console.WriteLine("echo $LastExitCode");
+            Console.WriteLine("To check the exit code returned by this application, run the following command.");
+            Console.WriteLine("On Windows: echo %errorlevel%");
+            Console.WriteLine("On OS X: echo $?");
 
             Environment.Exit(canBeZeroOrOne);
         }

--- a/MyService.cs
+++ b/MyService.cs
@@ -31,7 +31,7 @@ namespace poc_windowsservice_preflightcheck
             }
 
             Console.WriteLine("To check the exit code returned by this application, run the following command.");
-            Console.WriteLine("On Windows: echo %errorlevel%");
+            Console.WriteLine("On Windows: cmd /c echo %errorlevel%");
             Console.WriteLine("On OS X: echo $?");
 
             Environment.Exit(canBeZeroOrOne);

--- a/Program.cs
+++ b/Program.cs
@@ -16,7 +16,7 @@ namespace poc_windowsservice_preflightcheck
             {
                 x.Service<MyService>(s =>
                 {
-                    if (ApplicationStartup.GetStartupMode() == StartupMode.RunPreflightCheck)
+                    if (ApplicationStartup.GetStartupMode() == StartupMode.Preflight)
                         s.WhenStarted(service => service.PreFlightCheck());
                     else
                         s.WhenStarted(service => service.Start());

--- a/Program.cs
+++ b/Program.cs
@@ -32,7 +32,7 @@ namespace poc_windowsservice_preflightcheck
                 x.SetServiceName("MyTopShelfService");
 
                 // TopShelf requires the --preflight command-line switch to be whitelisted
-                x.AddCommandLineSwitch("preflight", preflight => Console.WriteLine("Application started in pre-flight mode. Running pre-flight check."));
+                x.AddCommandLineSwitch("preflight", ignore => ignore.ToString());
             });
         }
     }

--- a/Program.cs
+++ b/Program.cs
@@ -10,15 +10,17 @@ namespace poc_windowsservice_preflightcheck
 {
     class Program
     {
-        static bool _preflight = false;
-
         public static void Main(string[] args)
         {
             HostFactory.Run(x =>
             {
                 x.Service<MyService>(s =>
                 {
-                    s.WhenStarted(service => service.Start(_preflight));
+                    if (ApplicationStartup.GetStartupMode() == StartupMode.RunPreflightCheck)
+                        s.WhenStarted(service => service.PreFlightCheck());
+                    else
+                        s.WhenStarted(service => service.Start());
+                    
                     s.WhenStopped(service => service.Stop());
                     s.ConstructUsing(() => new MyService());
                 });
@@ -29,7 +31,8 @@ namespace poc_windowsservice_preflightcheck
                 x.SetDisplayName("My TopShelf service");
                 x.SetServiceName("MyTopShelfService");
 
-                x.AddCommandLineSwitch("preflight", preflight => _preflight = preflight);
+                // TopShelf requires the --preflight command-line switch to be whitelisted
+                x.AddCommandLineSwitch("preflight", preflight => Console.WriteLine("Application started in pre-flight mode. Running pre-flight check."));
             });
         }
     }

--- a/README.md
+++ b/README.md
@@ -71,3 +71,15 @@ Topshelf v4.0.0.0, .NET Framework v4.0.30319.42000
 Pre-flight mode wasn't specified. Running normally.
 The MyTopShelfService service is now running, press Control+C to exit.
 ```
+
+## Checking for exit code
+The various platforms have different ways of inspecting the exit code of an application:
+
+### Windows command prompt
+`echo %errorlevel%`
+
+### PowerShell
+Either `$lastExitCode` or `$?`, see [here](https://www.safaribooksonline.com/library/view/windows-powershell-cookbook/9780596528492/ch01s11.html) for more details.
+
+### Linux and OS/X
+`echo $?`

--- a/README.md
+++ b/README.md
@@ -22,7 +22,28 @@ The pre-flight mode will cause the process to return with a 0 exit code (success
 
 # Sample output
 
-```PS Microsoft.PowerShell.Core\FileSystem::Debug> .\poc-windowsservice-preflightcheck.exe --preflight
+### Pre-flight mode (success)
+
+```
+PS> .\poc-windowsservice-preflightcheck.exe --preflight
+Configuration Result:
+[Success] Name MyTopShelfService
+[Success] DisplayName My TopShelf service
+[Success] Description Service that has a pre-flight check. Run with --preflight argument to test.
+[Success] ServiceName MyTopShelfService
+Topshelf v4.0.0.0, .NET Framework v4.0.30319.42000
+Running a preflight check...
+Pre-flight check successful. Process is ready to run!
+Returning exit code 0.
+To check the exit code returned by this application, run the following command.
+On Windows: cmd /c echo %errorlevel%
+On OS X: echo $?
+```
+
+### Pre-flight mode (failure)
+
+```
+PS> .\poc-windowsservice-preflightcheck.exe --preflight
 Configuration Result:
 [Success] Name MyTopShelfService
 [Success] DisplayName My TopShelf service
@@ -32,9 +53,21 @@ Topshelf v4.0.0.0, .NET Framework v4.0.30319.42000
 Running a preflight check...
 Pre-flight check failed.
 Returning exit code 1.
-Type the following command on your Powershell terminal to find the exit code of the most recently exited process:
-echo $LastExitCode
+To check the exit code returned by this application, run the following command.
+On Windows: cmd /c echo %errorlevel%
+On OS X: echo $?
+```
 
-PS Microsoft.PowerShell.Core\FileSystem::Debug> echo $LastExitCode
-1
+### Normal service start
+
+```
+PS>.\poc-windowsservice-preflightcheck.exe
+Configuration Result:
+[Success] Name MyTopShelfService
+[Success] DisplayName My TopShelf service
+[Success] Description Service that has a pre-flight check. Run with --preflight argument to test.
+[Success] ServiceName MyTopShelfService
+Topshelf v4.0.0.0, .NET Framework v4.0.30319.42000
+Pre-flight mode wasn't specified. Running normally.
+The MyTopShelfService service is now running, press Control+C to exit.
 ```

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="CommandLineParser" version="1.9.71" targetFramework="net461" />
   <package id="Topshelf" version="4.0.3" targetFramework="net461" />
 </packages>

--- a/poc-windowsservice-preflightcheck.csproj
+++ b/poc-windowsservice-preflightcheck.csproj
@@ -48,6 +48,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ApplicationStartup.cs" />
+    <Compile Include="CommandLineOptions.cs" />
     <Compile Include="MyService.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/poc-windowsservice-preflightcheck.csproj
+++ b/poc-windowsservice-preflightcheck.csproj
@@ -32,6 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="CommandLine, Version=1.9.71.2, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
+      <HintPath>packages\CommandLineParser.1.9.71\lib\net45\CommandLine.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />


### PR DESCRIPTION
Adds a NuGet package and an abstraction to determine how the service should launch itself.

NuGet package: https://github.com/gsscoder/commandline
Abstraction: `ApplicationLaunch` class providing en enum of type `StartupMode` that can have the value `RunNormally` or `RunPreflightCheck`.